### PR TITLE
Update to SDL3, reorder version SetAttributes to work on MacOS

### DIFF
--- a/TexDyn.hpp
+++ b/TexDyn.hpp
@@ -7,7 +7,7 @@ Date Modified: Janurary 26, 2025
 #define _DYNAMIC_TEXTURE_HPP__
 
 #include <GL/glew.h>
-#include <SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <atomic>


### PR DESCRIPTION
* Updated SDL2 functions to SDL3
* Moved the SDL SetAttributes for version 4.1 to before the window is created (and added two flags), which is apparently needed on MacOS
* Set SDL's log priority to verbose (might help with debugging anything)
* Moved camera closer to the rendered plane