### PR TITLE
Modification of buildBuffers function (mesh parameter)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
+# Author: Everton Albuquerque de Oliveira
+# Date Created: September 24, 2025
+
 LIBS = -lSDL3 -lGL -lGLEW
+CC = g++
 
 simulation: main.o TexDyn.o ThreadPool.o
-	g++ *.o -o simulation $(LIBS)
+	$(CC) *.o -o simulation $(LIBS)
 
 main.o: TexDyn.hpp main.cpp
-	g++ main.cpp -c
+	$(CC) main.cpp -c
 
 TexDyn.o: TexDyn.cpp TexDyn.hpp
-	g++ TexDyn.cpp -c
+	$(CC) TexDyn.cpp -c
 
 ThreadPool.o: ThreadPool.cpp ThreadPool.hpp
-	g++ ThreadPool.cpp -c
+	$(CC) ThreadPool.cpp -c
 
 clean:
 	rm *.o simulation

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+LIBS = -lSDL3 -lGL -lGLEW
+
+simulation: main.o TexDyn.o ThreadPool.o
+	g++ *.o -o simulation $(LIBS)
+
+main.o: TexDyn.hpp main.cpp
+	g++ main.cpp -c
+
+TexDyn.o: TexDyn.cpp TexDyn.hpp
+	g++ TexDyn.cpp -c
+
+ThreadPool.o: ThreadPool.cpp ThreadPool.hpp
+	g++ ThreadPool.cpp -c
+
+clean:
+	rm *.o simulation

--- a/ThreadPool.cpp
+++ b/ThreadPool.cpp
@@ -1,0 +1,165 @@
+/*
+Author: Dan Rehberg
+Date Modified: January 28, 2025
+Purpose: Thread pool that can switch between sleeping and spinning threads for more control in parallel workflow.
+Pending: Modification made to pass data for data parallel work in the dispatch function call
+			this avoids the inability to conveniently pass a non-static member function to the dispatch work function pointer.
+			Getting around this could rely on Functors and Templates, but this keeps the single function call agnostic to types
+				by exploiting a static cast to void*
+			This is reasonable secure in preserving ownership and security as private class data could only be passed through
+				the class invoking a dispatch request (getting to define which work function has permission to modify their data).
+*/
+
+#include "ThreadPool.hpp"
+#include <iostream>
+
+ThreadsPool::ThreadsPool(size_t count) : bells(wakeUp, std::defer_lock), quit(false), spin(true), threadCount(count)
+{
+	clock = 0;
+
+	workPartial = 0;
+	workTotal = 0;
+
+	threadPool = new std::thread[threadCount];
+	wake = new volatile size_t[threadCount + 1];
+	waiting.store(0);
+	for (size_t i = 0; i < threadCount; ++i)
+	{
+		threadPool[i] = std::move(std::thread(&ThreadsPool::g, this, i + 1));
+		wake[i + 1] = 0;
+	}
+
+	while (waiting != threadCount) {}
+}
+
+ThreadsPool::~ThreadsPool()
+{
+	workPartial = 0;
+	workTotal = 0;
+	quit = true;
+	waiting.store(0);
+	clock = wake[1] + 1;
+	sleep.notify_all();
+
+	for (size_t i = 0; i < threadCount; ++i)
+		threadPool[i].join();
+
+	funcData = nullptr;
+	funcTask = nullptr;
+
+	delete[] threadPool;
+	delete[] wake;
+
+	threadPool = nullptr;
+	wake = nullptr;
+}
+
+//[[TO DO]], 1/26/2024 -- will be including this behavior again for functions which have access to global data being processed
+/*void ThreadsPool::dispatch(size_t totalWork, void(*job)(std::mutex&, size_t, size_t), bool postSpin)
+{
+	funcData = job;
+	workTotal = totalWork;
+	size_t partial = (totalWork + threadCount) / (threadCount + 1);
+	workPartial = partial;
+	parallelData = true;
+	bool prevSpin = spin;
+	spin = postSpin;
+	waiting.store(0);
+	++clock;
+	if (!prevSpin)
+	{
+		//for (size_t i = 1; i < threadCount; ++i)wake[i] = true;
+		//std::lock_guard<std::mutex> alarm(wakeUp);
+		bells.lock();//Pessimism be damned, notify all does not otherwise guarantee dispatch of all available threads :( without acquiring the lock
+		sleep.notify_all();
+		bells.unlock();
+		//std::cout << clock << '\n';
+	}
+
+
+	if (partial > totalWork) partial = totalWork;
+	job(m, 0, partial);
+
+	while (waiting != threadCount) {}
+}*/
+
+void ThreadsPool::dispatch(size_t totalWork, void(*job)(std::mutex&, size_t, size_t, void*), void* _data, bool postSpin)
+{
+	data = _data;
+	funcData = job;
+	workTotal = totalWork;
+	size_t partial = (totalWork + threadCount) / (threadCount + 1);
+	workPartial = partial;
+	parallelData = true;
+	bool prevSpin = spin;
+	spin = postSpin;
+	waiting.store(0);
+	++clock;
+	if (!prevSpin)
+	{
+		//for (size_t i = 1; i < threadCount; ++i)wake[i] = true;
+		//std::lock_guard<std::mutex> alarm(wakeUp);
+		bells.lock();//Pessimism be damned, notify all does not otherwise guarantee dispatch of all available threads :( without acquiring the lock
+		sleep.notify_all();
+		bells.unlock();
+		//std::cout << clock << '\n';
+	}
+
+
+	if (partial > totalWork) partial = totalWork;
+	job(m, 0, partial, _data);
+
+	while (waiting != threadCount) {}
+}
+
+void ThreadsPool::g(const size_t id)
+{
+	std::unique_lock<std::mutex> alarmClock(wakeUp, std::defer_lock);
+
+	while (!quit)
+	{
+		waiting.fetch_add(1);
+		size_t next = wake[id] + 1;
+		if (spin)
+			while (next != clock) {}
+		else//Note, this might need to be distinct bools for each thread
+		{
+			alarmClock.lock();
+			sleep.wait(alarmClock, [&]() {return next == clock; });
+			alarmClock.unlock();
+		}
+
+		/*while (next != clock)
+		{
+			if (!spin)
+			{
+				//std::unique_lock<std::mutex> alarmClock(wakeUp);
+				alarmClock.lock();
+				sleep.wait(alarmClock, [&]() {return next == clock; });
+				alarmClock.unlock();
+			}
+		}*/
+		size_t partial = workPartial, total = workTotal;
+		size_t t0 = id * partial;
+		size_t t1 = t0 + partial;
+		if (t0 >= total)
+		{
+			t0 = total;
+			t1 = total;
+		}
+		else if (t1 > total)t1 = total;
+
+		if (parallelData) {
+			if (t0 < t1) funcData(m, t0, t1, data);//funcData(m, t0, t1);
+        } else
+			for (size_t i = t0; i < t1; ++i)
+				funcTask(m, i);
+		wake[id] = next;
+	}
+}
+
+ThreadsPool& ThreadsPool::pool()
+{
+	static ThreadsPool pool(5);
+	return pool;
+}

--- a/ThreadPool.hpp
+++ b/ThreadPool.hpp
@@ -1,0 +1,58 @@
+/*
+Author: Dan Rehberg
+Date: 12/26/2024
+Purpose: Thread pool class that can be accessed and depolyed in most applications.
+	This is achieved by defining the system as a singleton for general global access.
+		Granted, this could pose issues with the threads accessing the pool.
+	Pool offers two execution paths for best use of Data and Task parallelism.
+	Pool can also have the threads switch between sleep and spinning states.
+	The thread dispatching this pool can also be involved in the execution process.
+Pending: Update changes described in source file.
+*/
+
+#ifndef __THREADS_POOL__
+#define __THREADS_POOL__
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+class ThreadsPool final
+{
+public:
+	//Data parallel execution
+	//void dispatch(size_t totalWork, void(*job)(std::mutex&, size_t, size_t), bool postSpin = false);
+	//	Version 2, pass in the shared data to work over
+	void dispatch(size_t totalWork, void(*job)(std::mutex&, size_t, size_t, void*), void* data = nullptr, bool postSpin = false);
+	//Task parallel execution
+	void dispatch(size_t totalWork, void(*job)(std::mutex&, size_t), bool postSpin = false);
+	static ThreadsPool& pool();
+private:
+	ThreadsPool(size_t count);
+	~ThreadsPool();
+	ThreadsPool(const ThreadsPool&) = delete;
+	ThreadsPool& operator=(const ThreadsPool&) = delete;
+	std::unique_lock<std::mutex> bells;
+	volatile size_t clock;
+	void* volatile data = nullptr;
+	//void(* volatile funcData)(std::mutex&, size_t, size_t) = nullptr;
+	void(* volatile funcData)(std::mutex&, size_t, size_t, void*) = nullptr;
+	void(*funcTask)(std::mutex&, size_t) = nullptr;
+	void g(const std::size_t id);
+	std::mutex m;
+	volatile bool parallelData;
+	volatile bool quit;
+	std::condition_variable sleep;
+	volatile bool spin;
+	const size_t threadCount;
+	std::thread* threadPool;
+	volatile size_t* wake;
+	std::mutex wakeUp;
+	volatile std::atomic_uint16_t waiting;
+	volatile size_t workPartial;
+	volatile size_t workTotal;
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@ Author: Daniel Rehberg, Finley Huggins
 Date Created: Janurary 26, 2025
 */
 
+#include <SDL3/SDL_error.h>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -16,6 +17,23 @@ Date Created: Janurary 26, 2025
 #include <glm/gtc/matrix_transform.hpp>
 #include "TexDyn.hpp"
 
+// Original mesh before buildBuffers was modified
+std::vector<float> TEST_MESH = {
+		-1.0f, 0.0f, -1.0f,
+		-1.0f, 0.0f, 1.0f,
+		1.0f, 0.0f, -1.0f,
+		1.0f, 0.0f, -1.0f,
+		-1.0f, 0.0f, 1.0f,
+		1.0f, 0.0f, 1.0f,
+		0.0f, 1.0f,
+		0.0f, 0.0f,
+		1.0f, 1.0f,
+		1.0f, 1.0f,
+		0.0f, 0.0f,
+		1.0f, 0.0f
+	};
+
+
 constexpr int RESX = 1280;
 constexpr int RESY = 720;
 
@@ -25,7 +43,7 @@ GLint uniProj, uniView, uniModel, uniTex;
 
 void buildShaders();
 void closeShaders();
-void buildBuffers();
+void buildBuffers(std::vector<float> mesh);
 void closeBuffers();
 
 std::uint32_t testing[1024 * 1024];
@@ -39,6 +57,7 @@ int main(int argc, char** argv)
 	//SETUP
 	SDL_Window* window = nullptr;
 	SDL_GLContext context;
+
 	if (!SDL_Init(SDL_INIT_VIDEO))
 	{
 		std::cerr << "Failed to initialize SDL: " << SDL_GetError();
@@ -79,7 +98,7 @@ int main(int argc, char** argv)
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
 	buildShaders();
-	buildBuffers();
+	buildBuffers(TEST_MESH);
 
 	DynamicTexture dt;
 	dt.uploadTexture(tex);
@@ -221,23 +240,10 @@ void closeShaders()
 	program = 0;
 }
 
-void buildBuffers()
+void buildBuffers(std::vector<float> mesh)
 {
-	std::vector<float> mesh = {
-		-1.0f, 0.0f, -1.0f,
-		-1.0f, 0.0f, 1.0f,
-		1.0f, 0.0f, -1.0f,
-		1.0f, 0.0f, -1.0f,
-		-1.0f, 0.0f, 1.0f,
-		1.0f, 0.0f, 1.0f,
-		0.0f, 1.0f,
-		0.0f, 0.0f,
-		1.0f, 1.0f,
-		1.0f, 1.0f,
-		0.0f, 0.0f,
-		1.0f, 0.0f
-	};
-	verts = 6;
+	
+    verts = mesh.size() / 5; // Three floats for xyz coords and two for uv coords
 
 	glGenVertexArrays(1, &vao);
 	glGenBuffers(1, &vbo);
@@ -247,7 +253,7 @@ void buildBuffers()
 	glEnableVertexAttribArray(0);
 	glEnableVertexAttribArray(1);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void*)0);
-	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, (void*)(4 * 3 * verts));
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, (void*)(sizeof(float) * 3 * verts));
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
 	GLenum err;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 /*
-Author: Daniel Rehberg, Finley Huggins
-Date Created: Janurary 26, 2025
+Author: Daniel Rehberg, Finley Huggins, Everton Albuquerque de Oliveira
+Date Created: January 26, 2025
 */
 
 #include <SDL3/SDL_error.h>


### PR DESCRIPTION
Added a parameter `std::vector<float> mesh` to the buildBuffers function, allowing it to receive mesh data from other parts of the program. This parameter contains all the xyz coordinates followed by all the uv coordinates, in respective order. The number of vertices is calculated within the function itself based on the size of the mesh vector.

The original mesh data was moved to the top of the program as `std::vector<float> TEST_MESH` so that the program still works as before, but this may be deleted once the mesh creating function is implemented. 