### PR TITLE
Add displacement to vertices in vertex shader

### DIFF
--- a/vert.txt
+++ b/vert.txt
@@ -1,6 +1,6 @@
 /*
-Author: Daniel Rehberg
-Date Modified: Janurary 26, 2025
+Authors: Daniel Rehberg, Finley Huggins
+Date Modified: October 2, 2025
 */
 
 #version 410
@@ -13,12 +13,17 @@ uniform mat4 proj;
 uniform mat4 view;
 //END MOVE TO A UBO
 
+// TODO: we ultimately want more than just a single square
 uniform mat4 model;
+uniform usampler2D tex;
 
 smooth out vec2 texCoord;
 
 void main()
 {
+    uvec4 data = texture(tex, uv);
+
 	texCoord = uv;
-	gl_Position = proj * view * model * vec4(pos.xyz, 1.0);
+    // the /100 is arbitrary
+	gl_Position = proj * view * model * vec4(pos.x, pos.y + data.a/100.0, pos.z, 1.0);
 }


### PR DESCRIPTION
Since the code isn't integrated together with others' work, the effect is sort of lame, but the `tex` texture is now used as a displacement map for the four vertices of the main mesh. The program still runs. When rotating the mesh, the mesh can become slightly offset, depending on where the sand is.